### PR TITLE
feat: добавлены модальные окна

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -2,6 +2,7 @@ import { Route, Routes } from 'react-router-dom'
 
 import AuthForm from './AuthForm'
 import RegisterForm from './RegisterForm'
+import TestSettings from './TestSettings'
 import GoalDonutChart from './ui/GoalDonutChart'
 import GoalProgressBar from './ui/GoalProgressBar'
 
@@ -12,6 +13,7 @@ function App() {
         <Routes>
           <Route element={<AuthForm />} path="/auth" />
           <Route element={<RegisterForm />} path="/register" />
+          <Route element={<TestSettings />} path="/settings" />
           <Route element={<GoalDonutChart percent={100} />} path="/donut" />
           <Route
             element={

--- a/src/components/AuthForm.tsx
+++ b/src/components/AuthForm.tsx
@@ -58,28 +58,24 @@ const AuthForm = () => {
         <legend className="from-light-green-text to-light-blue-text mb-10 bg-gradient-to-r bg-clip-text text-center text-2xl font-medium text-transparent md:text-2xl">
           Вход
         </legend>
-        <label className="mb-3.5 flex flex-col items-start justify-start" htmlFor="username">
-          <span className="mb-2.5 text-xs uppercase text-[#2B2B2B] md:text-base">
-            АДРЕС ЭЛЕКТРОННОЙ ПОЧТЫ
-          </span>
-          <Input
-            error={errors.username ? true : false}
-            id="username"
-            name="username"
-            register={register}
-            type="email"
-          />
-        </label>
-        <label className="mb-2 flex flex-col items-start justify-start" htmlFor="password">
-          <span className="mb-2.5 text-xs uppercase text-[#2B2B2B] md:text-base">ПАРОЛЬ</span>
-          <Input
-            error={errors.password ? true : false}
-            id="password"
-            name="password"
-            register={register}
-            type="password"
-          />
-        </label>
+        <Input
+          error={errors.username ? true : false}
+          id="username"
+          label="Адрес электронной почты"
+          name="username"
+          placeholder=""
+          register={register}
+          type="email"
+        />
+        <Input
+          error={errors.password ? true : false}
+          id="password"
+          label="Пароль"
+          name="password"
+          placeholder=""
+          register={register}
+          type="password"
+        />
         <div className="mb-6 flex min-w-full justify-between">
           {(errors.username || errors.password || loginError) && (
             <p className="text-xs text-[#FF6F6F] md:mr-5 md:text-base">
@@ -95,18 +91,23 @@ const AuthForm = () => {
             Забыли пароль?
           </a>
         </div>
-        <label className="mb-8 flex items-center" htmlFor="remember_password">
-          <Input
-            id="remember_password"
-            name="remember_password"
-            register={register}
-            type="checkbox"
-          />
-          <span className="ml-3 text-xs font-light text-[#2B2B2B] md:text-base">
-            Запомнить аккаунт
-          </span>
-        </label>
-        <Button disable={!isValid}>Войти</Button>
+        <Input
+          error={errors.password ? true : false}
+          id="remember_password"
+          label="Запомнить аккаунт"
+          name="remember_password"
+          placeholder=""
+          register={register}
+          type="checkbox"
+        />
+        <Button
+          background="from-light-green to-light-blue bg-gradient-to-r"
+          disable={!isValid}
+          textColor="text-white"
+          onClick={() => console.log('submit')}
+        >
+          {'Войти'}
+        </Button>
       </fieldset>
       <div className="flex items-center justify-between">
         <Link className="mr-5 text-xs font-light text-[#07836C] md:text-base" to="/register">

--- a/src/components/RegisterForm.tsx
+++ b/src/components/RegisterForm.tsx
@@ -69,84 +69,71 @@ const RegisterForm = () => {
         <legend className="from-light-green-text to-light-blue-text mb-4 bg-gradient-to-r bg-clip-text text-center text-xl font-medium text-transparent sm:text-2xl md:mb-10">
           Создать учетную запись
         </legend>
-        <label
-          className="mb-2 flex flex-col items-start justify-start sm:mb-1 lg:mb-3"
-          htmlFor="last_name"
-        >
-          <span className="mb-1 text-[#2B2B2B] sm:text-base md:text-xl xl:mb-0">Фамилия*</span>
-          <Input
-            error={errors.last_name ? true : false}
-            id="last_name"
-            name="last_name"
-            register={register}
-            type="text"
-          />
-        </label>
-        <label
-          className="mb-2 flex flex-col items-start justify-start sm:mb-1 lg:mb-3"
-          htmlFor="first_name"
-        >
-          <span className="mb-1 text-[#2B2B2B] sm:text-base md:text-xl xl:mb-0">Имя*</span>
-          <Input
-            error={errors.first_name ? true : false}
-            id="first_name"
-            name="first_name"
-            register={register}
-            type="text"
-          />
-        </label>
-        <label
-          className="mb-2 flex flex-col items-start justify-start sm:mb-1 lg:mb-3"
-          htmlFor="middle_name"
-        >
-          <span className="mb-1 text-[#2B2B2B] sm:text-base md:text-xl xl:mb-0">Отчество</span>
-          <Input id="middle_name" name="middle_name" register={register} type="text" />
-        </label>
-        <label
-          className="mb-2 flex flex-col items-start justify-start sm:mb-1 lg:mb-3"
-          htmlFor="password"
-        >
-          <span className="mb-1 text-[#2B2B2B] sm:text-base md:text-xl xl:mb-0">Пароль*</span>
-          <Input
-            error={errors.password ? true : false}
-            id="password"
-            name="password"
-            register={register}
-            type="password"
-          />
-        </label>
-        <label
-          className="mb-2 flex flex-col items-start justify-start sm:mb-1 lg:mb-3"
-          htmlFor="email"
-        >
-          <span className="mb-1 text-[#2B2B2B] sm:text-base md:text-xl xl:mb-0">E-mail*</span>
-          <Input
-            error={errors.email ? true : false}
-            id="email"
-            name="email"
-            register={register}
-            type="email"
-          />
-        </label>
-        <label
-          className="mb-2 flex flex-col items-start justify-start sm:mb-1 lg:mb-3"
-          htmlFor="date_of_birth"
-        >
-          <span className="mb-1 text-[#2B2B2B] sm:text-base md:text-xl xl:mb-0">
-            Дата рождения*
-          </span>
-          <Input
-            error={errors.date_of_birth ? true : false}
-            id="date_of_birth"
-            name="date_of_birth"
-            register={register}
-            type="date"
-          />
-        </label>
+        <Input
+          error={errors.last_name ? true : false}
+          id="last_name"
+          label="Фамилия*"
+          name="last_name"
+          placeholder=""
+          register={register}
+          type="text"
+        />
+        <Input
+          error={errors.first_name ? true : false}
+          id="first_name"
+          label="Имя*"
+          name="first_name"
+          placeholder=""
+          register={register}
+          type="text"
+        />
+        <Input
+          error={errors.first_name ? true : false}
+          id="middle_name"
+          label="Отчество"
+          name="middle_name"
+          placeholder=""
+          register={register}
+          type="text"
+        />
+        <Input
+          error={errors.password ? true : false}
+          id="password"
+          label="Пароль*"
+          name="password"
+          placeholder=""
+          register={register}
+          type="password"
+        />
+        <Input
+          error={errors.email ? true : false}
+          id="email"
+          label="E-mail*"
+          name="email"
+          placeholder=""
+          register={register}
+          type="email"
+        />
+        <Input
+          error={errors.date_of_birth ? true : false}
+          id="date_of_birth"
+          label="Дата рождения*"
+          name="date_of_birth"
+          placeholder=""
+          register={register}
+          type="date"
+        />
         <span className="mb-4 text-sm text-[#7C7C7C] md:text-base">
           *Обязательное поле для ввода
         </span>
-        <Button disable={!isValid}>Продолжить</Button>
+        <Button
+          background="from-light-green to-light-blue bg-gradient-to-r"
+          disable={!isValid}
+          textColor="text-white"
+          onClick={() => console.log('submit')}
+        >
+          {'Продолжить'}
+        </Button>
       </fieldset>
       <div className="flex flex-wrap items-center justify-between">
         <Link className="mr-5 text-sm font-light text-[#07836C] md:text-base" to="/auth">

--- a/src/components/TestSettings.tsx
+++ b/src/components/TestSettings.tsx
@@ -71,8 +71,8 @@ const AuthForm = () => {
         close="Назад"
         inputs={[
           { id: '', label: 'Имя', placeholder: 'имяяя', name: 'name', type: 'text' },
-          { id: '', label: 'Имя', placeholder: 'имяяя', name: 'name', type: 'password' },
-          { id: '', label: 'Имя', placeholder: 'имяяя', name: 'поле', type: 'checkbox' }
+          { id: '', label: 'Имя', placeholder: 'имяяя', name: 'password', type: 'password' },
+          { id: '', label: 'Имя', placeholder: 'имяяя', name: 'field', type: 'checkbox' }
         ]}
         open={isModalInputOpen}
         title="Заголовок модального окна"

--- a/src/components/TestSettings.tsx
+++ b/src/components/TestSettings.tsx
@@ -72,7 +72,7 @@ const AuthForm = () => {
         inputs={[
           { id: '', label: 'Имя', placeholder: 'имяяя', name: 'name', type: 'text' },
           { id: '', label: 'Имя', placeholder: 'имяяя', name: 'name', type: 'password' },
-          { id: '', label: 'Имя', placeholder: 'имяяя', name: 'name', type: 'checkbox' }
+          { id: '', label: 'Имя', placeholder: 'имяяя', name: 'поле', type: 'checkbox' }
         ]}
         open={isModalInputOpen}
         title="Заголовок модального окна"

--- a/src/components/TestSettings.tsx
+++ b/src/components/TestSettings.tsx
@@ -1,0 +1,107 @@
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import * as z from 'zod'
+import { Link } from 'react-router-dom'
+import { useState } from 'react'
+
+import ModalInputsBtns from './ui/modals/ModalInputsBtns'
+import ModalBtns from './ui/modals/ModalBtns'
+
+const schema = z.object({
+  email: z.string().email({ message: 'Неверный логин или пароль' }),
+  password: z.string().nonempty({ message: 'Неверный логин или пароль' }),
+  remember_password: z.boolean()
+})
+
+const AuthForm = () => {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isValid }
+  } = useForm({
+    mode: 'onBlur',
+    resolver: zodResolver(schema)
+  })
+  const [isModalInputOpen, setIsModalInputOpen] = useState(false)
+  const [isModalBtnOpen, setIsModalBtnOpen] = useState(false)
+  const [modalType, setModalType] = useState('inputs')
+
+  const onSubmit = (data: object) => {
+    console.log(data)
+  }
+
+  return (
+    <form
+      className="mx-2.5 rounded-3xl bg-[#E5E5E5CC]/80 px-2.5 py-8 font-sans font-normal tracking-normal sm:px-6 md:max-w-md md:px-12 md:py-14"
+      onSubmit={handleSubmit(onSubmit)}
+    >
+      <div className="mt-5 flex flex-col items-center justify-between">
+        <button
+          className="text-xs font-light text-[#3076B8] md:text-base"
+          onClick={() => {
+            setIsModalInputOpen(true)
+          }}
+        >
+          кнопки и инпуты
+        </button>
+        <button
+          className="text-xs font-light text-[#3076B8] md:text-base"
+          onClick={() => {
+            setIsModalBtnOpen(true)
+          }}
+        >
+          кнопки
+        </button>
+      </div>
+      <ModalInputsBtns
+        buttons={[
+          {
+            background: 'from-light-red to-light-blue bg-gradient-to-r',
+            textColor: 'text-white',
+            children: 'Отправить',
+            onClick: () => console.log('Submitted')
+          },
+          {
+            background: 'from-light-green to-light-blue bg-gradient-to-r',
+            textColor: 'text-white',
+            children: 'Назад',
+            onClick: () => console.log('Submitted')
+          }
+        ]}
+        close="Назад"
+        inputs={[
+          { id: '', label: 'Имя', placeholder: 'имяяя', name: 'name', type: 'text' },
+          { id: '', label: 'Имя', placeholder: 'имяяя', name: 'name', type: 'password' },
+          { id: '', label: 'Имя', placeholder: 'имяяя', name: 'name', type: 'checkbox' }
+        ]}
+        open={isModalInputOpen}
+        title="Заголовок модального окна"
+        onClose={() => setIsModalInputOpen(false)}
+      />
+
+      <ModalBtns
+        buttons={[
+          {
+            background: 'bg-white',
+            textColor: 'black',
+            children: 'Отправить',
+            onClick: () => console.log('Submitted')
+          },
+          {
+            background: 'from-light-red to-light-blue bg-gradient-to-r',
+            textColor: 'text-white',
+            children: 'Назад',
+            onClick: () => console.log('Submitted')
+          }
+        ]}
+        close="Назад"
+        direction="flex-col"
+        open={isModalBtnOpen}
+        title="Модальное окно с кнопками"
+        onClose={() => setIsModalBtnOpen(false)}
+      />
+    </form>
+  )
+}
+
+export default AuthForm

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,31 +1,22 @@
 interface Button {
   disable?: boolean
   children: string
+  background: string
+  textColor: string
+  onClick: () => void
 }
 
 const Button = ({ ...props }: Button) => {
   return (
     <button
-      className="
-      from-light-green to-light-blue
-      active:shadow-custom
-      focus:border-blue-focus
-      max-h-12
-      w-full
-      rounded-full
-      bg-gradient-to-r
-      py-3
-      text-base
-      font-light
-      text-white
-      focus:border-2
-      focus:outline-0
-      disabled:bg-gray-500
-      disabled:bg-none
-      md:text-xl
-      "
+      className={`${props.background} max-h-12 flex-1 rounded-full py-3 px-2 text-base font-light ${props.textColor} mx-2 mt-3 disabled:bg-gray-500 disabled:bg-none sm:mx-5 md:text-xl`}
       disabled={props.disable}
       type="submit"
+      onClick={(event) => {
+        event.stopPropagation()
+        event.preventDefault()
+        props.onClick()
+      }}
     >
       {props.children}
     </button>

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -3,6 +3,7 @@ import { FieldValues, UseFormRegister } from 'react-hook-form'
 
 import closeEye from '../../assets/images/close_eye.svg'
 import openEye from '../../assets/images/open_eye.svg'
+import checkMark from '../../assets/images/check_mark.svg'
 
 interface InputProps {
   id: string
@@ -39,6 +40,7 @@ const Input = ({ ...props }: InputProps) => {
               className={`text-true-gray-900 placeholder:text-light-gray -mr-10 max-h-12 w-full rounded-full py-4 px-6 pr-12 text-xl font-normal ${
                 props.error ? 'bg-error border-light-red border-2' : 'bg-[#ECECEC]}'
               }`}
+              disabled={props.disabled}
               id={props.id}
               name={props.name}
               placeholder={props.placeholder}
@@ -59,15 +61,16 @@ const Input = ({ ...props }: InputProps) => {
         <div className="mb-5 flex items-center">
           <input
             {...props.register(props.name)}
-            className="peer relative h-5 w-5 shrink-0 appearance-none rounded-sm
-                    border
-                    bg-[#ECECEC]
-                    checked:bg-[url('./src/assets/images/check_mark.svg')]
-                    checked:bg-[length:20px]
-                    checked:bg-no-repeat
-                    checked:content-['']
-                    hover:ring
-                    hover:ring-gray-300"
+            className={`peer checked:bg-[url(' relative h-5 w-5 shrink-0 appearance-none
+              rounded-sm
+              border
+              bg-[#ECECEC]${checkMark}')]
+              checked:bg-[length:20px]
+              checked:bg-no-repeat
+              checked:content-['']
+              hover:ring
+              hover:ring-gray-300`}
+            disabled={props.disabled}
             id={props.id}
             name={props.name}
             placeholder={props.placeholder}
@@ -94,6 +97,7 @@ const Input = ({ ...props }: InputProps) => {
             className={`text-true-gray-900 placeholder:text-light-gray max-h-12 w-full rounded-full py-4 px-6 text-lg font-normal ${
               props.error ? 'bg-error border-light-red border-2' : 'bg-[#ECECEC]}'
             }`}
+            disabled={props.disabled}
             id={props.id}
             name={props.name}
             placeholder={props.placeholder}

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -36,7 +36,7 @@ const Input = ({ ...props }: InputProps) => {
             <input
               {...props.register(props.name)}
               aria-invalid={props.error}
-              className={`text-true-gray-900 placeholder:text-light-gray -mr-10 max-h-12 w-full rounded-full py-4 px-6 text-xl font-normal ${
+              className={`text-true-gray-900 placeholder:text-light-gray -mr-10 max-h-12 w-full rounded-full py-4 px-6 pr-12 text-xl font-normal ${
                 props.error ? 'bg-error border-light-red border-2' : 'bg-[#ECECEC]}'
               }`}
               id={props.id}

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -46,8 +46,8 @@ const Input = ({ ...props }: InputProps) => {
                 alt={isPasswordVisible ? 'скрыть пароль' : 'показать пароль'}
                 src={
                   isPasswordVisible
-                    ? 'src/assets/images/close_eye.svg'
-                    : 'src/assets/images/open_eye.svg'
+                    ? './src/assets/images/close_eye.svg'
+                    : './src/assets/images/open_eye.svg'
                 }
               />
             </button>

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -1,6 +1,9 @@
 import { useState } from 'react'
 import { FieldValues, UseFormRegister } from 'react-hook-form'
 
+import closeEye from '../../assets/images/close_eye.svg'
+import openEye from '../../assets/images/open_eye.svg'
+
 interface InputProps {
   id: string
   name: string
@@ -44,11 +47,7 @@ const Input = ({ ...props }: InputProps) => {
             <button onClick={togglePasswordVisibility}>
               <img
                 alt={isPasswordVisible ? 'скрыть пароль' : 'показать пароль'}
-                src={
-                  isPasswordVisible
-                    ? './src/assets/images/close_eye.svg'
-                    : './src/assets/images/open_eye.svg'
-                }
+                src={isPasswordVisible ? closeEye : openEye}
               />
             </button>
           </div>

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -1,13 +1,11 @@
 import { useState } from 'react'
 import { FieldValues, UseFormRegister } from 'react-hook-form'
 
-import closeEye from '../../assets/images/close_eye.svg'
-import openEye from '../../assets/images/open_eye.svg'
-
 interface InputProps {
   id: string
   name: string
   type: string
+  label: string
   register: UseFormRegister<FieldValues>
   placeholder?: string
   error?: boolean
@@ -25,63 +23,82 @@ const Input = ({ ...props }: InputProps) => {
   switch (props.type) {
     case 'password':
       return (
-        <div className="flex w-full content-center items-center">
-          <input
-            {...props.register(props.name)}
-            aria-invalid={props.error}
-            className={`text-light-gray placeholder:text-light-gray focus:border-blue-focus -mr-10 max-h-12 w-full appearance-none rounded-full py-4 px-6 pr-12 text-xl font-normal focus:border-2 focus:outline-0 ${
-              props.error ? 'bg-error border-light-red border-2' : 'bg-[#ECECEC]}'
-            }`}
-            id={props.id}
-            name={props.name}
-            placeholder={props.placeholder}
-            type={isPasswordVisible ? 'text' : 'password'}
-          />
-          <button
-            className="focus:border-blue-focus border-2  border-transparent focus:border-2 focus:outline-0"
-            onClick={togglePasswordVisibility}
-          >
-            <img
-              alt={isPasswordVisible ? 'скрыть пароль' : 'показать пароль'}
-              src={isPasswordVisible ? closeEye : openEye}
+        <div className="mb-2">
+          <label className="true-gray-900 sm:text-base md:text-xl" htmlFor={props.name}>
+            {props.label}
+          </label>
+          <div className="flex w-full content-center items-center">
+            <input
+              {...props.register(props.name)}
+              aria-invalid={props.error}
+              className={`text-true-gray-900 placeholder:text-light-gray -mr-10 max-h-12 w-full rounded-full py-4 px-6 text-xl font-normal ${
+                props.error ? 'bg-error border-light-red border-2' : 'bg-[#ECECEC]}'
+              }`}
+              id={props.id}
+              name={props.name}
+              placeholder={props.placeholder}
+              type={isPasswordVisible ? 'text' : 'password'}
             />
-          </button>
+            <button onClick={togglePasswordVisibility}>
+              <img
+                alt={isPasswordVisible ? 'скрыть пароль' : 'показать пароль'}
+                src={
+                  isPasswordVisible
+                    ? 'src/assets/images/close_eye.svg'
+                    : 'src/assets/images/open_eye.svg'
+                }
+              />
+            </button>
+          </div>
         </div>
       )
 
     case 'checkbox':
       return (
-        <input
-          {...props.register(props.name)}
-          className="peer focus:border-blue-focus relative h-5 w-5 shrink-0 appearance-none rounded-sm
-                  border
-                  bg-[#ECECEC]
-                  checked:bg-[url('assets/images/check_mark.svg')]
-                  checked:bg-[length:20px]
-                  checked:bg-no-repeat
-                  checked:content-['']
-                  hover:ring
-                  hover:ring-gray-300 focus:border-2 focus:outline-0"
-          id={props.id}
-          name={props.name}
-          placeholder={props.placeholder}
-          type={props.type}
-        />
+        <div className="mb-5 flex items-center">
+          <input
+            {...props.register(props.name)}
+            className="peer relative h-5 w-5 shrink-0 appearance-none rounded-sm
+                    border
+                    bg-[#ECECEC]
+                    checked:bg-[url('./src/assets/images/check_mark.svg')]
+                    checked:bg-[length:20px]
+                    checked:bg-no-repeat
+                    checked:content-['']
+                    hover:ring
+                    hover:ring-gray-300"
+            id={props.id}
+            name={props.name}
+            placeholder={props.placeholder}
+            type={props.type}
+          />
+          <label
+            className="ml-3 text-xs font-light text-[#2B2B2B] md:text-base"
+            htmlFor={props.name}
+          >
+            {props.label}
+          </label>
+        </div>
       )
 
     default:
       return (
-        <input
-          {...props.register(props.name)}
-          aria-invalid={props.error}
-          className={`text-light-gray placeholder:text-light-gray focus:border-blue-focus max-h-12 w-full rounded-full py-4 px-6 text-xl font-normal focus:border-2 focus:outline-0 ${
-            props.error ? 'bg-error border-light-red border-2' : 'bg-[#ECECEC]}'
-          }`}
-          id={props.id}
-          name={props.name}
-          placeholder={props.placeholder}
-          type={props.type}
-        />
+        <div className="mb-2">
+          <label className="true-gray-900 sm:text-base md:text-xl" htmlFor={props.name}>
+            {props.label}
+          </label>
+          <input
+            {...props.register(props.name)}
+            aria-invalid={props.error}
+            className={`text-true-gray-900 placeholder:text-light-gray max-h-12 w-full rounded-full py-4 px-6 text-lg font-normal ${
+              props.error ? 'bg-error border-light-red border-2' : 'bg-[#ECECEC]}'
+            }`}
+            id={props.id}
+            name={props.name}
+            placeholder={props.placeholder}
+            type={props.type}
+          />
+        </div>
       )
   }
 }

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -61,15 +61,22 @@ const Input = ({ ...props }: InputProps) => {
         <div className="mb-5 flex items-center">
           <input
             {...props.register(props.name)}
-            className={`peer checked:bg-[url(' relative h-5 w-5 shrink-0 appearance-none
-              rounded-sm
-              border
-              bg-[#ECECEC]${checkMark}')]
+            className={`
+              peer
+              checked:bg-[url('${checkMark}')]
+              relative
+              h-5
+              w-5
+              shrink-0
+              appearance-none
+              rounded-sm border
+              bg-[#ECECEC]
               checked:bg-[length:20px]
               checked:bg-no-repeat
               checked:content-['']
               hover:ring
-              hover:ring-gray-300`}
+              hover:ring-gray-300
+            `}
             disabled={props.disabled}
             id={props.id}
             name={props.name}

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -3,7 +3,7 @@ import { FieldValues, UseFormRegister } from 'react-hook-form'
 
 import closeEye from '../../assets/images/close_eye.svg'
 import openEye from '../../assets/images/open_eye.svg'
-import checkMark from '../../assets/images/check_mark.svg'
+// import checkMark from '../../assets/images/check_mark.svg' в идеале лучше сделать через import
 
 interface InputProps {
   id: string
@@ -63,14 +63,15 @@ const Input = ({ ...props }: InputProps) => {
             {...props.register(props.name)}
             className={`
               peer
-              checked:bg-[url('${checkMark}')]
               relative
               h-5
               w-5
               shrink-0
               appearance-none
-              rounded-sm border
+              rounded-sm
+              border
               bg-[#ECECEC]
+              checked:bg-[url('assets/images/check_mark.svg')]
               checked:bg-[length:20px]
               checked:bg-no-repeat
               checked:content-['']

--- a/src/components/ui/modals/ModalBtns.tsx
+++ b/src/components/ui/modals/ModalBtns.tsx
@@ -42,6 +42,15 @@ const ModalBtns = ({ ...props }: ModalProps) => {
       handleClose()
     }
   })
+  const handleBackdropClick = (e: React.MouseEvent) => {
+    if (
+      props.open &&
+      dialogContentRef.current &&
+      !dialogContentRef.current.contains(e.target as Node)
+    ) {
+      handleClose()
+    }
+  }
 
   document.querySelector('main')?.addEventListener('click', (e) => {
     if (

--- a/src/components/ui/modals/ModalBtns.tsx
+++ b/src/components/ui/modals/ModalBtns.tsx
@@ -1,0 +1,113 @@
+import { useEffect, useRef } from 'react'
+import { useForm } from 'react-hook-form'
+
+import Button from '../Button'
+
+interface ModalProps {
+  open: boolean
+  onClose: () => void
+  direction: string
+  buttons: { background: string; textColor: string; children: string; onClick: () => void }[]
+  title: string
+  close: string
+}
+
+const ModalBtns = ({ ...props }: ModalProps) => {
+  const dialogRef = useRef<HTMLDivElement>(null)
+  const dialogContentRef = useRef<HTMLDivElement>(null)
+
+  const {
+    register,
+    formState: { errors }
+  } = useForm()
+
+  useEffect(() => {
+    if (dialogRef.current) {
+      if (props.open) {
+        dialogRef.current.showModal()
+      } else {
+        dialogRef.current.close()
+      }
+    }
+  }, [props.open])
+
+  function handleClose() {
+    if (dialogRef.current) {
+      dialogRef.current.close()
+    }
+
+    props.onClose()
+  }
+
+  function onClick() {
+    // здесь действие при нажатии на кнопку
+  }
+
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape') {
+      handleClose()
+    }
+  })
+
+  document.querySelector('main')?.addEventListener('click', (e) => {
+    if (
+      props.open &&
+      dialogContentRef.current &&
+      !dialogContentRef.current.contains(e.target as Node)
+    ) {
+      handleClose()
+    }
+  })
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    props.onClose()
+  }
+
+  return props.open ? (
+    <dialog
+      ref={dialogRef}
+      className="inset-0 flex items-center justify-center bg-transparent"
+      role="dialog"
+    >
+      <div className="fixed top-0 left-0 z-10 h-screen w-screen backdrop-blur backdrop-opacity-40" />
+      <div
+        ref={dialogContentRef}
+        className="relative z-20 flex max-w-full flex-col gap-6 rounded-3xl bg-[#848484] bg-opacity-50 px-10 py-4 backdrop-blur backdrop-opacity-80 sm:py-10 sm:px-16 md:px-9 md:py-14 lg:py-9 lg:px-14"
+      >
+        <div className="flex justify-center">
+          <span className="text-xl text-white sm:text-2xl">{props.title}</span>
+          {props.close === '' ? (
+            <button
+              autoFocus
+              className="absolute top-2 right-2 p-2 focus:outline-none focus-visible:outline-white"
+              onClick={handleClose}
+            >
+              <img alt="Close modal" src="src/assets/images/cross.svg" />
+            </button>
+          ) : null}
+        </div>
+        <form className={`flex ${props.direction} justify-center`} onSubmit={handleSubmit}>
+          {props.buttons.map((button, index) => (
+            <Button
+              key={index}
+              background={button.background}
+              textColor={button.textColor}
+              onClick={() => {
+                if (props.close === button.children) {
+                  handleClose()
+                } else {
+                  onClick()
+                }
+              }}
+            >
+              {button.children}
+            </Button>
+          ))}
+        </form>
+      </div>
+    </dialog>
+  ) : null
+}
+
+export default ModalBtns

--- a/src/components/ui/modals/ModalBtns.tsx
+++ b/src/components/ui/modals/ModalBtns.tsx
@@ -12,7 +12,7 @@ interface ModalProps {
 }
 
 const ModalBtns = ({ ...props }: ModalProps) => {
-  const dialogRef = useRef<HTMLDivElement>(null)
+  const dialogRef = useRef<HTMLDialogElement>(null)
   const dialogContentRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {

--- a/src/components/ui/modals/ModalBtns.tsx
+++ b/src/components/ui/modals/ModalBtns.tsx
@@ -34,7 +34,7 @@ const ModalBtns = ({ ...props }: ModalProps) => {
   }
 
   function onClick() {
-    // здесь действие при нажатии на кнопку
+    // здесь действие при нажатии на кнопку..
   }
 
   document.addEventListener('keydown', (e) => {
@@ -51,16 +51,6 @@ const ModalBtns = ({ ...props }: ModalProps) => {
       handleClose()
     }
   }
-
-  document.querySelector('main')?.addEventListener('click', (e) => {
-    if (
-      props.open &&
-      dialogContentRef.current &&
-      !dialogContentRef.current.contains(e.target as Node)
-    ) {
-      handleClose()
-    }
-  })
 
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault()

--- a/src/components/ui/modals/ModalBtns.tsx
+++ b/src/components/ui/modals/ModalBtns.tsx
@@ -62,6 +62,7 @@ const ModalBtns = ({ ...props }: ModalProps) => {
       ref={dialogRef}
       className="inset-0 flex items-center justify-center bg-transparent"
       role="dialog"
+      onClick={handleBackdropClick}
     >
       <div className="fixed top-0 left-0 z-10 h-screen w-screen backdrop-blur backdrop-opacity-40" />
       <div

--- a/src/components/ui/modals/ModalInputsBtns.tsx
+++ b/src/components/ui/modals/ModalInputsBtns.tsx
@@ -22,15 +22,29 @@ const ModalInputsBtns = ({ ...props }: ModalProps) => {
     formState: { errors }
   } = useForm()
 
-  useEffect(() => {
-    if (dialogRef.current) {
-      if (props.open) {
-        dialogRef.current.showModal()
-      } else {
-        dialogRef.current.close()
+  const ModalInputsBtns = ({ open, onClose }: ModalProps) => {
+    // ...
+    useEffect(() => {
+      function Close() {
+        if (dialogRef.current) {
+          dialogRef.current.close()
+        }
+        onClose()
       }
-    }
-  }, [props.open])
+      if (dialogRef.current) {
+        if (open) {
+          dialogRef.current.showModal()
+        } else {
+          dialogRef.current.close()
+        }
+        dialogRef.current?.addEventListener('click', (e) => {
+          if (e.target instanceof Node && !dialogRef.current?.contains(e.target)) {
+            Close()
+          }
+        })
+      }
+    }, [open, onClose])
+  }
 
   function handleClose() {
     if (dialogRef.current) {
@@ -50,15 +64,20 @@ const ModalInputsBtns = ({ ...props }: ModalProps) => {
     }
   })
 
-  document.querySelector('main')?.addEventListener('click', (e) => {
-    if (
-      props.open &&
-      dialogContentRef.current &&
-      !dialogContentRef.current.contains(e.target as Node)
-    ) {
-      handleClose()
-    }
-  })
+  const mainElement = document.querySelector('main')
+
+  if (mainElement) {
+    mainElement.addEventListener('click', (e) => {
+      if (
+        props.open &&
+        dialogRef.current &&
+        e.target instanceof Node &&
+        !dialogRef.current.contains(e.target as Node)
+      ) {
+        handleClose()
+      }
+    })
+  }
 
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault()

--- a/src/components/ui/modals/ModalInputsBtns.tsx
+++ b/src/components/ui/modals/ModalInputsBtns.tsx
@@ -1,0 +1,128 @@
+import { useEffect, useRef } from 'react'
+import { useForm } from 'react-hook-form'
+
+import Input from '../Input'
+import Button from '../Button'
+
+interface ModalProps {
+  open: boolean
+  onClose: () => void
+  inputs: { id: string; label: string; placeholder: string; name: string; type: string }[]
+  buttons: { background: string; textColor: string; children: string; onClick: () => void }[]
+  title: string
+  close: string
+}
+
+const ModalInputsBtns = ({ ...props }: ModalProps) => {
+  const dialogContentRef = useRef<HTMLDivElement>(null)
+  const dialogRef = useRef<HTMLDialogElement>(null)
+
+  const {
+    register,
+    formState: { errors }
+  } = useForm()
+
+  useEffect(() => {
+    if (dialogRef.current) {
+      if (props.open) {
+        dialogRef.current.showModal()
+      } else {
+        dialogRef.current.close()
+      }
+    }
+  }, [props.open])
+
+  function handleClose() {
+    if (dialogRef.current) {
+      dialogRef.current.close()
+    }
+
+    props.onClose()
+  }
+
+  function onClick() {
+    // здесь действие при нажатии на кнопку
+  }
+
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape') {
+      handleClose()
+    }
+  })
+
+  document.querySelector('main')?.addEventListener('click', (e) => {
+    if (
+      props.open &&
+      dialogContentRef.current &&
+      !dialogContentRef.current.contains(e.target as Node)
+    ) {
+      handleClose()
+    }
+  })
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    props.onClose()
+  }
+
+  return props.open ? (
+    <dialog
+      ref={dialogRef}
+      className="inset-0 flex items-center justify-center bg-transparent"
+      role="dialog"
+    >
+      <div className="fixed top-0 left-0 z-10 h-screen w-screen backdrop-blur backdrop-opacity-40" />
+      <div
+        ref={dialogContentRef}
+        className="relative z-20 flex max-w-full flex-col gap-6 rounded-3xl bg-[#848484] bg-opacity-50 px-10 py-4 backdrop-blur backdrop-opacity-80 sm:py-10 sm:px-16 md:px-9 md:py-14 lg:py-9 lg:px-14"
+      >
+        <div className="flex justify-center">
+          <span className="text-xl text-white sm:text-2xl">{props.title}</span>
+          {props.close === '' ? (
+            <button
+              autoFocus
+              className="absolute top-2 right-2 p-2 focus:outline-none focus-visible:outline-white"
+              onClick={handleClose}
+            >
+              <img alt="Close modal" src="src/assets/images/cross.svg" />
+            </button>
+          ) : null}
+        </div>
+        <form onSubmit={handleSubmit}>
+          {props.inputs.map((input, index) => (
+            <Input
+              key={index}
+              error={false}
+              id={input.id}
+              label={input.label}
+              name={input.name}
+              placeholder={input.placeholder}
+              register={register}
+              type={input.type}
+            />
+          ))}
+          <div className="flex flex-row justify-center">
+            {props.buttons.map((button, index) => (
+              <Button
+                key={index}
+                background={button.background}
+                textColor={button.textColor}
+                onClick={() => {
+                  if (props.close === button.children) {
+                    handleClose()
+                  } else {
+                    onClick()
+                  }
+                }}
+              >
+                {button.children}
+              </Button>
+            ))}
+          </div>
+        </form>
+      </div>
+    </dialog>
+  ) : null
+}
+
+export default ModalInputsBtns


### PR DESCRIPTION
Модальные окна

## Описание изменений

добавил 2 модальных окна, которые можно закастомить и переиспользовать в других компонентах

## Тестирование
путь **settings/**
на странице 2 кнопки которые открывают два разных модальных окна
### 1 Модальное окно
![2023-05-03_03-19-59](https://user-images.githubusercontent.com/59705273/235811866-faf29c34-bccd-4eec-b30c-629e54678a72.png)
можно настроить:

Кнопки
1. задний план кнопки
2. цвет текста
3. текст
4. действие при клике

Инпуты
1. id
2. текст для label
3. placeholder
4. name
5. type

Относящееся к модальному окну:

1. переменная от которой открывается окно (true)
2. заголовок
3. закрытие

### 2 Модальное окно
![2023-05-03_03-26-51](https://user-images.githubusercontent.com/59705273/235812532-610ea065-e48f-45d6-bf5f-b89b928ff286.png)
можно настроить:

Кнопки
1. задний план кнопки
2. цвет текста
3. текст
4. действие при клике

Относящееся к модальному окну:

1. направление кнопок
2. переменная от которой открывается окно (true)
3. заголовок
4. закрытие

## Update

1. добавлена возможность создавать кнопки которые закрывают модальное окно 
передаем через close текст кнопки (children) , кнопка с одинаковым close и children будет закрывать модальное окно
![2023-05-04_00-15-34](https://user-images.githubusercontent.com/59705273/236051685-fb8abdb1-716d-46be-8c94-1fd519a2f489.png)

2. исправлены ошибки предыдущего pull request-а (кроме тех что связаны с файлом TestSettings т.к он нужен только для демонстрации модальных окон и в дальнейшем использоваться не будет!)
